### PR TITLE
delete: アイテムメニューの表示を削除

### DIFF
--- a/src/system/gameView.js
+++ b/src/system/gameView.js
@@ -21,10 +21,6 @@ class gameView {
         this.canvasStyle.drawBackground(); // 背景の描画
         this.canvasStyle.drawGameScreen(0, 3); // スコアとライフの表示
 
-        // アイテムメニューの表示
-        const items = ['Item 1', 'Item 2', 'Item 3'];
-        this.canvasStyle.drawItemMenu(items);
-
         this.player.movePlayer();
         this.player.drawPlayer(this.ctx);
         // プレイヤーの弾の管理


### PR DESCRIPTION
うっかり消さなければならない箇所を消し忘れたため改めてブランチを切り直して削除を行いました。
アイテムに関する仕様変更に伴い、プレイ画面に表示されるアイテム欄を削除しています。